### PR TITLE
samples: matter: Added setting power for Thread devices that use FEM

### DIFF
--- a/samples/matter/common/src/thread_util.cpp
+++ b/samples/matter/common/src/thread_util.cpp
@@ -11,20 +11,12 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 #include <openthread/platform/radio.h>
 #include <platform/OpenThread/OpenThreadUtils.h>
 #endif
 
 #include <zephyr/zephyr.h>
-
-#ifdef CONFIG_MPSL_FEM
-#ifndef CONFIG_FEM_802_15_4_DEFAULT_TX_POWER
-#define CONFIG_FEM_802_15_4_DEFAULT_TX_POWER 20
-#endif
-constexpr static int8_t kMinThreadOutputPower = -40;
-constexpr static int8_t kMaxThreadOutputPower = 20;
-#endif
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
 {
@@ -57,20 +49,16 @@ void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
 #endif
 }
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 CHIP_ERROR SetDefaultThreadOutputPower()
 {
 	CHIP_ERROR err;
 	/* set output power when FEM is active */
-	if (CONFIG_FEM_802_15_4_DEFAULT_TX_POWER != 0 &&
-	    CONFIG_FEM_802_15_4_DEFAULT_TX_POWER >= kMinThreadOutputPower &&
-	    CONFIG_FEM_802_15_4_DEFAULT_TX_POWER <= kMaxThreadOutputPower) {
-		err = chip::DeviceLayer::Internal::MapOpenThreadError(
-			otPlatRadioSetTransmitPower(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(),
-						    static_cast<int8_t>(CONFIG_FEM_802_15_4_DEFAULT_TX_POWER)));
-	} else {
-		return CHIP_ERROR_INVALID_INTEGER_VALUE;
-	}
+	chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+	err = chip::DeviceLayer::Internal::MapOpenThreadError(
+		otPlatRadioSetTransmitPower(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(),
+					    static_cast<int8_t>(CONFIG_OPENTHREAD_DEFAULT_TX_POWER)));
+	chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
 	return err;
 }
 #endif

--- a/samples/matter/common/src/thread_util.cpp
+++ b/samples/matter/common/src/thread_util.cpp
@@ -11,7 +11,20 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
+#ifdef CONFIG_MPSL_FEM
+#include <openthread/platform/radio.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#endif
+
 #include <zephyr/zephyr.h>
+
+#ifdef CONFIG_MPSL_FEM
+#ifndef CONFIG_FEM_802_15_4_DEFAULT_TX_POWER
+#define CONFIG_FEM_802_15_4_DEFAULT_TX_POWER 20
+#endif
+constexpr static int8_t kMinThreadOutputPower = -40;
+constexpr static int8_t kMaxThreadOutputPower = 20;
+#endif
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
 {
@@ -43,3 +56,21 @@ void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
 	chip::app::DnssdServer::Instance().StartServer();
 #endif
 }
+
+#ifdef CONFIG_MPSL_FEM
+CHIP_ERROR SetDefaultThreadOutputPower()
+{
+	CHIP_ERROR err;
+	/* set output power when FEM is active */
+	if (CONFIG_FEM_802_15_4_DEFAULT_TX_POWER != 0 &&
+	    CONFIG_FEM_802_15_4_DEFAULT_TX_POWER >= kMinThreadOutputPower &&
+	    CONFIG_FEM_802_15_4_DEFAULT_TX_POWER <= kMaxThreadOutputPower) {
+		err = chip::DeviceLayer::Internal::MapOpenThreadError(
+			otPlatRadioSetTransmitPower(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(),
+						    static_cast<int8_t>(CONFIG_FEM_802_15_4_DEFAULT_TX_POWER)));
+	} else {
+		return CHIP_ERROR_INVALID_INTEGER_VALUE;
+	}
+	return err;
+}
+#endif

--- a/samples/matter/common/src/thread_util.h
+++ b/samples/matter/common/src/thread_util.h
@@ -7,5 +7,10 @@
 #pragma once
 
 #include <cstdint>
+#include <core/CHIPError.h>
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp = 0);
+
+#ifdef CONFIG_MPSL_FEM
+CHIP_ERROR SetDefaultThreadOutputPower();
+#endif

--- a/samples/matter/common/src/thread_util.h
+++ b/samples/matter/common/src/thread_util.h
@@ -11,6 +11,6 @@
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp = 0);
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 CHIP_ERROR SetDefaultThreadOutputPower();
 #endif

--- a/samples/matter/light_bulb/Kconfig
+++ b/samples/matter/light_bulb/Kconfig
@@ -7,19 +7,18 @@ mainmenu "Matter nRF Connect Light Bulb Example Application"
 
 if MPSL_FEM
 
-config FEM_802_15_4_DEFAULT_TX_POWER
+config OPENTHREAD_DEFAULT_TX_POWER
 	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
 	default 20
 	help
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
-if FEM_802_15_4_DEFAULT_TX_POWER != 0
-
 config MPSL_FEM_NRF21540_TX_GAIN_DB
-	default 20
-endif
-endif
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/light_bulb/Kconfig
+++ b/samples/matter/light_bulb/Kconfig
@@ -15,6 +15,10 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0 
+# to set the output power to a similar value as for nRF52840DK.
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 

--- a/samples/matter/light_bulb/Kconfig
+++ b/samples/matter/light_bulb/Kconfig
@@ -5,6 +5,22 @@
 #
 mainmenu "Matter nRF Connect Light Bulb Example Application"
 
+if MPSL_FEM
+
+config FEM_802_15_4_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+if FEM_802_15_4_DEFAULT_TX_POWER != 0
+
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20
+endif
+endif
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -96,6 +96,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_MPSL_FEM
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Can not set Default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -96,10 +96,10 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 	err = SetDefaultThreadOutputPower();
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Can not set Default Thread output power");
+		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
 #endif

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -25,20 +25,18 @@ config STATE_LEDS
 
 if MPSL_FEM
 
-config FEM_802_15_4_DEFAULT_TX_POWER
+config OPENTHREAD_DEFAULT_TX_POWER
 	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
 	default 20
 	help
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
-if FEM_802_15_4_DEFAULT_TX_POWER != 0
-
-# see subsys/mpsl/fem for full definition
 config MPSL_FEM_NRF21540_TX_GAIN_DB
-	default 20
-endif
-endif
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -33,6 +33,10 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0 
+# to set the output power to a similar value as for nRF52840DK.
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -23,6 +23,23 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config FEM_802_15_4_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+if FEM_802_15_4_DEFAULT_TX_POWER != 0
+
+# see subsys/mpsl/fem for full definition
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20
+endif
+endif
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -106,10 +106,10 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 	err = SetDefaultThreadOutputPower();
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Can not set Default Thread output power");
+		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
 #endif

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -106,6 +106,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_MPSL_FEM
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Can not set Default Thread output power");
+		return err;
+	}
+#endif
+
 	LightSwitch::GetInstance().Init(kLightSwitchEndpointId);
 
 	/* Initialize UI components */

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -14,6 +14,22 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config FEM_802_15_4_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+if FEM_802_15_4_DEFAULT_TX_POWER != 0
+
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20
+endif
+endif
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -24,6 +24,10 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0 
+# to set the output power to a similar value as for nRF52840DK.
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -16,19 +16,19 @@ config STATE_LEDS
 
 if MPSL_FEM
 
-config FEM_802_15_4_DEFAULT_TX_POWER
+config OPENTHREAD_DEFAULT_TX_POWER
 	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
 	default 20
 	help
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
-if FEM_802_15_4_DEFAULT_TX_POWER != 0
-
 config MPSL_FEM_NRF21540_TX_GAIN_DB
-	default 20
-endif
-endif
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -97,10 +97,10 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 	err = SetDefaultThreadOutputPower();
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Can not set Default Thread output power");
+		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
 #endif

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -97,6 +97,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_MPSL_FEM
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Can not set Default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);

--- a/samples/matter/template/Kconfig
+++ b/samples/matter/template/Kconfig
@@ -15,6 +15,10 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0 
+# to set the output power to a similar value as for nRF52840DK.
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 

--- a/samples/matter/template/Kconfig
+++ b/samples/matter/template/Kconfig
@@ -7,20 +7,19 @@ mainmenu "Matter nRF Connect Template Example Application"
 
 if MPSL_FEM
 
-config FEM_802_15_4_DEFAULT_TX_POWER
+config OPENTHREAD_DEFAULT_TX_POWER
 	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
 	default 20
 	help
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
-if FEM_802_15_4_DEFAULT_TX_POWER != 0
-
 config MPSL_FEM_NRF21540_TX_GAIN_DB
-	default 20
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 
-endif
-endif
+endif # MPSL_FEM
+
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/template/Kconfig
+++ b/samples/matter/template/Kconfig
@@ -5,6 +5,23 @@
 #
 mainmenu "Matter nRF Connect Template Example Application"
 
+if MPSL_FEM
+
+config FEM_802_15_4_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+if FEM_802_15_4_DEFAULT_TX_POWER != 0
+
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20
+
+endif
+endif
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -86,10 +86,10 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 	err = SetDefaultThreadOutputPower();
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Can not set Default Thread output power");
+		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
 #endif

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -86,6 +86,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_MPSL_FEM
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Can not set Default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -14,6 +14,22 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config FEM_802_15_4_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+if FEM_802_15_4_DEFAULT_TX_POWER != 0
+
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20
+endif
+endif
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -24,6 +24,10 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0 
+# to set the output power to a similar value as for nRF52840DK.
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
 

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -16,19 +16,19 @@ config STATE_LEDS
 
 if MPSL_FEM
 
-config FEM_802_15_4_DEFAULT_TX_POWER
+config OPENTHREAD_DEFAULT_TX_POWER
 	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
 	default 20
 	help
 	  Use this setting to set the default Thread (802.15.4) output power for device that
 	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
 
-if FEM_802_15_4_DEFAULT_TX_POWER != 0
-
 config MPSL_FEM_NRF21540_TX_GAIN_DB
-	default 20
-endif
-endif
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -102,10 +102,10 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
-#ifdef CONFIG_MPSL_FEM
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
 	err = SetDefaultThreadOutputPower();
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Can not set Default Thread output power");
+		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
 #endif

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -102,6 +102,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_MPSL_FEM
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Can not set Default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);


### PR DESCRIPTION
After recent FEM changes, we needed to set the Thread output power to 20 dBm and FEM gain to 20 dB to restore the previous behavior of nRF21DK within our samples.

Signed-off-by: Arkadiusz Balys <arkadiusz.balys@nordicsemi.no>