### PR TITLE
samples: matter: Enable Wi-Fi legacy power save mode

### DIFF
--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -40,6 +40,16 @@ config CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT
 
 endif # NET_L2_OPENTHREAD
 
+if CHIP_WIFI
+
+# Enable Legacy Power Save mode by default.
+# The device sleeps most of the time and wakes up on each DTIM interval.
+config NRF_WIFI_LOW_POWER
+	bool
+	default y
+
+endif # CHIP_WIFI
+
 if MPSL_FEM
 
 config OPENTHREAD_DEFAULT_TX_POWER

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -11,7 +11,8 @@ Matter: Light switch
 This light switch sample demonstrates the usage of the :ref:`Matter <ug_matter>` application layer to build a switch device that binds with lighting devices and changes the state of their LEDs.
 When configured together with the :ref:`Matter light bulb <matter_light_bulb_sample>` sample (or other lighting sample) and when using a Matter controller, the light switch can control one light bulb directly or a group of light bulbs remotely over a Matter network built on top of a low-power, 802.15.4 Thread, or on top of a Wi-Fi network.
 Support for both Thread and Wi-Fi is mutually exclusive and depends on the hardware platform, so only one protocol can be supported for a specific light switch device.
-In case of Thread, this device works as a Thread :ref:`Sleepy End Device <thread_ot_device_types>`.
+In case of Thread, this device works as a Thread :ref:`Sleepy End Device <thread_ot_device_types>`. 
+In case of Wi-Fi, this device works in ``legacy power save mode`` that means the device sleeps most of the time, and wakes up on each DTIM interval.
 You can use this sample as a reference for creating your own application.
 
 Requirements

--- a/samples/matter/light_switch/src/chip_project_config.h
+++ b/samples/matter/light_switch/src/chip_project_config.h
@@ -10,3 +10,11 @@
 /* Use a default pairing code if one hasn't been provisioned in flash. */
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+/* When WiFi low power mode is enabled, 
+ * increase MRP local active retry interval to work with 
+ * 3 DTIMs and the Beacon interval equal to 102.4 ms.
+*/
+#ifdef CONFIG_NRF_WIFI_LOW_POWER
+    #define CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE 1
+#endif

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -77,6 +77,16 @@ config CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT
 
 endif # NET_L2_OPENTHREAD
 
+if CHIP_WIFI
+
+# Enable Legacy Power Save mode by default.
+# The device sleeps most of the time and wakes up on each DTIM interval.
+config NRF_WIFI_LOW_POWER
+	bool
+	default y
+
+endif # CHIP_WIFI
+
 if MPSL_FEM
 
 config OPENTHREAD_DEFAULT_TX_POWER

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -11,7 +11,8 @@ Matter: Door lock
 This door lock sample demonstrates the usage of the :ref:`Matter <ug_matter>` application layer to build a door lock device with one basic bolt.
 This device works as a Matter accessory device, meaning it can be paired and controlled remotely over a Matter network built on top of a low-power 802.15.4 Thread or Wi-Fi network.
 Support for both Thread and Wi-Fi is mutually exclusive and depends on the hardware platform, so only one protocol can be supported for a specific lock device.
-In case of Thread, this device works as a Thread :ref:`Sleepy End Device <thread_ot_device_types>`.
+In case of Thread, this device works as a Thread :ref:`Sleepy End Device <thread_ot_device_types>`. 
+In case of Wi-Fi, this device works in ``legacy power save mode`` that means the device sleeps most of the time, and wakes up on each DTIM interval.
 You can use this sample as a reference for creating your application.
 
 Requirements

--- a/samples/matter/lock/src/chip_project_config.h
+++ b/samples/matter/lock/src/chip_project_config.h
@@ -18,3 +18,10 @@
 /* Use a default pairing code if one hasn't been provisioned in flash. */
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+#ifdef CONFIG_NRF_WIFI_LOW_POWER
+/* Enable overriding MRP params. 
+This config allows to increase MRP active interval according to current DTIM interval and the beacon interval.
+*/
+#define CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE 1
+#endif

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: f74a5eaefff3003edbed4dc0206803f1e972f912
+      revision: pull/180/head
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Enabled legacy power save mode for the light-switch and lock examples. Enabled overriding MRP parameters at runtime to set the proper values after getting
them from Wi-Fi Access Point.

Signed-off-by: Arkadiusz Balys <arkadiusz.balys@nordicsemi.no>