### PR TITLE
samples: matter: Introduce to Matter NUS service

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/nus.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus.rst
@@ -10,7 +10,7 @@ Nordic UART Service (NUS)
 The Bluetooth® LE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
 
 The NUS Service is used in the :ref:`peripheral_uart` sample.
-It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default.
+It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default, and with the :ref:`Matter door lock sample <matter_lock_sample>`, as an optional feature that extends the Bluetooth LE connectivity.
 
 Service UUID
 ************

--- a/samples/matter/common/src/bt_nus_service.cpp
+++ b/samples/matter/common/src/bt_nus_service.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "bt_nus_service.h"
+
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <zephyr/settings/settings.h>
+
+using namespace ::chip;
+using namespace ::chip::DeviceLayer;
+
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
+
+namespace
+{
+#if (CONFIG_BT_FIXED_PASSKEY)
+constexpr uint32_t kDefaultPasskey = 123456;
+#endif
+constexpr uint32_t kAdvertisingOptions = BT_LE_ADV_OPT_CONNECTABLE;
+constexpr uint8_t kAdvertisingFlags = BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR;
+} // namespace
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = NUSService::Connected,
+	.disconnected = NUSService::Disconnected,
+	.security_changed = NUSService::SecurityChanged,
+};
+struct bt_conn_auth_cb NUSService::sConnAuthCallbacks = {
+	.passkey_display = AuthPasskeyDisplay,
+	.cancel = AuthCancel,
+};
+struct bt_conn_auth_info_cb NUSService::sConnAuthInfoCallbacks = {
+	.pairing_complete = PairingComplete,
+	.pairing_failed = PairingFailed,
+};
+struct bt_nus_cb NUSService::sNusCallbacks = {
+	.received = RxCallback,
+};
+
+NUSService NUSService::sInstance;
+
+CHIP_ERROR NUSService::Init(const char *name, size_t nameLen, uint8_t priority, uint16_t minInterval,
+			    uint16_t maxInterval)
+{
+	VerifyOrReturnError(name && nameLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+
+	mAdvertisingItems[0] = BT_DATA(BT_DATA_FLAGS, &kAdvertisingFlags, sizeof(kAdvertisingFlags));
+	mAdvertisingItems[1] = BT_DATA(BT_DATA_NAME_COMPLETE, name, static_cast<uint8_t>(nameLen));
+
+	mServiceItems[0] = BT_DATA(BT_DATA_UUID128_ALL, BT_UUID_NUS_VAL, sizeof(BT_UUID_NUS_VAL));
+
+	mAdvertisingRequest.priority = priority;
+	mAdvertisingRequest.options = kAdvertisingOptions;
+	mAdvertisingRequest.minInterval = minInterval;
+	mAdvertisingRequest.maxInterval = maxInterval;
+	mAdvertisingRequest.advertisingData = Span<bt_data>(mAdvertisingItems);
+	mAdvertisingRequest.scanResponseData = Span<bt_data>(mServiceItems);
+
+	mAdvertisingRequest.onStarted = [](int rc) {
+		if (rc == 0) {
+			ChipLogDetail(DeviceLayer, "NUS BLE advertising started");
+		} else {
+			ChipLogError(DeviceLayer, "Failed to start NUS BLE advertising: %d", rc);
+		}
+	};
+	mAdvertisingRequest.onStopped = []() { ChipLogDetail(DeviceLayer, "NUS BLE advertising stopped"); };
+
+	settings_load();
+#if (CONFIG_BT_FIXED_PASSKEY)
+	VerifyOrReturnError(bt_passkey_set(kDefaultPasskey) != 0, CHIP_ERROR_INTERNAL);
+#endif
+	VerifyOrReturnError(bt_conn_auth_cb_register(&sConnAuthCallbacks) == 0, CHIP_ERROR_INTERNAL);
+	VerifyOrReturnError(bt_conn_auth_info_cb_register(&sConnAuthInfoCallbacks) == 0, CHIP_ERROR_INTERNAL);
+	VerifyOrReturnError(bt_nus_init(&sNusCallbacks) == 0, CHIP_ERROR_INTERNAL);
+
+	return CHIP_NO_ERROR;
+}
+
+void NUSService::StartServer()
+{
+	VerifyOrReturn(!mIsStarted, ChipLogError(DeviceLayer, "NUS service was already started"));
+
+	PlatformMgr().LockChipStack();
+	CHIP_ERROR ret = BLEAdvertisingArbiter::InsertRequest(mAdvertisingRequest);
+	PlatformMgr().UnlockChipStack();
+
+	if (CHIP_NO_ERROR != ret) {
+		ChipLogError(DeviceLayer, "Could not start NUS service");
+		mIsStarted = false;
+		return;
+	}
+	mIsStarted = true;
+	ChipLogProgress(DeviceLayer, "NUS service started");
+}
+
+void NUSService::StopServer()
+{
+	VerifyOrReturn(mIsStarted);
+
+	PlatformMgr().LockChipStack();
+	BLEAdvertisingArbiter::CancelRequest(mAdvertisingRequest);
+	PlatformMgr().UnlockChipStack();
+
+	mIsStarted = false;
+	ChipLogProgress(DeviceLayer, "NUS service stopped");
+}
+
+void NUSService::RxCallback(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
+{
+	VerifyOrReturn(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2);
+	ChipLogDetail(DeviceLayer, "NUS received: %d bytes", len);
+	GetNUSService().DispatchCommand(reinterpret_cast<const char *>(data), len);
+}
+
+CHIP_ERROR NUSService::RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context)
+{
+	VerifyOrReturnError(name, CHIP_ERROR_INVALID_ARGUMENT);
+
+	struct Command newCommand {};
+	memcpy(newCommand.command, name, length);
+	newCommand.commandLen = length;
+	newCommand.callback = callback;
+	newCommand.context = context;
+	mCommandsList.push_back(newCommand);
+
+	return CHIP_NO_ERROR;
+}
+
+void NUSService::DispatchCommand(const char *const data, uint16_t len)
+{
+	for (auto c : mCommandsList) {
+		if (strncmp(data, c.command, len) == 0) {
+			if (c.callback) {
+				PlatformMgr().LockChipStack();
+				c.callback(c.context);
+				PlatformMgr().UnlockChipStack();
+			}
+			return;
+		}
+	}
+	ChipLogError(DeviceLayer, "NUS command unkown!");
+}
+
+CHIP_ERROR NUSService::SendData(const char *const data, size_t length)
+{
+	VerifyOrReturnError(mBTConnection, CHIP_ERROR_SENDING_BLOCKED);
+	VerifyOrReturnError(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2,
+			    CHIP_ERROR_SENDING_BLOCKED);
+	VerifyOrReturnError(bt_nus_send(mBTConnection, reinterpret_cast<const uint8_t *const>(data), length) == 0,
+			    CHIP_ERROR_SENDING_BLOCKED);
+	return CHIP_NO_ERROR;
+}
+
+void NUSService::Connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err) {
+		ChipLogError(DeviceLayer, "NUS Connection failed (err %u)", err);
+		return;
+	}
+
+	bt_conn_set_security(conn, BT_SECURITY_L3);
+
+	char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	ChipLogDetail(DeviceLayer, "NUS BT Connected to %s", addr);
+}
+
+void NUSService::Disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	ChipLogProgress(DeviceLayer, "NUS BT Disconnected from %s (reason %u)", addr, reason);
+}
+
+void NUSService::SecurityChanged(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	if (!err) {
+		char addr[BT_ADDR_LE_STR_LEN];
+		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		ChipLogDetail(DeviceLayer, "NUS BT Security changed: %s level %u", addr, level);
+
+		GetNUSService().mBTConnection = bt_conn_ref(conn);
+	} else {
+		ChipLogError(DeviceLayer, "NUS BT Security failed: level %u err %d", level, err);
+	}
+}
+
+void NUSService::AuthPasskeyDisplay(struct bt_conn *conn, unsigned int passkey)
+{
+	ChipLogProgress(DeviceLayer, "PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: %d", passkey);
+}
+
+void NUSService::AuthCancel(struct bt_conn *conn)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	ChipLogProgress(DeviceLayer, "NUS BT Pairing cancelled: %s", addr);
+
+	bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+}
+
+void NUSService::PairingComplete(struct bt_conn *conn, bool bonded)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	ChipLogDetail(DeviceLayer, "NUS BT Pairing completed: %s, bonded: %d", addr, bonded);
+}
+
+void NUSService::PairingFailed(struct bt_conn *conn, enum bt_security_err reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	ChipLogError(DeviceLayer, "NUS BT Pairing failed to %s : reason %d", addr, static_cast<uint8_t>(reason));
+}

--- a/samples/matter/common/src/bt_nus_service.cpp
+++ b/samples/matter/common/src/bt_nus_service.cpp
@@ -1,58 +1,55 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include "bt_nus_service.h"
 
-#include <lib/support/logging/CHIPLogging.h>
-#include <platform/CHIPDeviceLayer.h>
-
+#include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
+
+#include <platform/CHIPDeviceLayer.h>
 
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
+#define NUS_BT_NAME (CONFIG_BT_DEVICE_NAME "_NUS")
+
 namespace
 {
-#if (CONFIG_BT_FIXED_PASSKEY)
-constexpr uint32_t kDefaultPasskey = 123456;
-#endif
 constexpr uint32_t kAdvertisingOptions = BT_LE_ADV_OPT_CONNECTABLE;
 constexpr uint8_t kAdvertisingFlags = BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR;
-} // namespace
+constexpr uint8_t kBTUuid[16] = { 158, 202, 220, 36, 14, 229, 169, 224, 147, 243, 163, 181, 1, 0, 64, 110 };
+} /* namespace */
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = NUSService::Connected,
 	.disconnected = NUSService::Disconnected,
 	.security_changed = NUSService::SecurityChanged,
 };
-struct bt_conn_auth_cb NUSService::sConnAuthCallbacks = {
+bt_conn_auth_cb NUSService::sConnAuthCallbacks = {
 	.passkey_display = AuthPasskeyDisplay,
 	.cancel = AuthCancel,
 };
-struct bt_conn_auth_info_cb NUSService::sConnAuthInfoCallbacks = {
+bt_conn_auth_info_cb NUSService::sConnAuthInfoCallbacks = {
 	.pairing_complete = PairingComplete,
 	.pairing_failed = PairingFailed,
 };
-struct bt_nus_cb NUSService::sNusCallbacks = {
+bt_nus_cb NUSService::sNusCallbacks = {
 	.received = RxCallback,
 };
 
 NUSService NUSService::sInstance;
 
-CHIP_ERROR NUSService::Init(const char *name, size_t nameLen, uint8_t priority, uint16_t minInterval,
-			    uint16_t maxInterval)
+bool NUSService::Init(uint8_t priority, uint16_t minInterval, uint16_t maxInterval)
 {
-	VerifyOrReturnError(name && nameLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
-
 	mAdvertisingItems[0] = BT_DATA(BT_DATA_FLAGS, &kAdvertisingFlags, sizeof(kAdvertisingFlags));
-	mAdvertisingItems[1] = BT_DATA(BT_DATA_NAME_COMPLETE, name, static_cast<uint8_t>(nameLen));
+	mAdvertisingItems[1] = BT_DATA(BT_DATA_NAME_COMPLETE, NUS_BT_NAME, strlen(NUS_BT_NAME));
 
-	mServiceItems[0] = BT_DATA(BT_DATA_UUID128_ALL, BT_UUID_NUS_VAL, sizeof(BT_UUID_NUS_VAL));
+	mServiceItems[0] = BT_DATA(BT_DATA_UUID128_ALL, kBTUuid, sizeof(kBTUuid));
 
 	mAdvertisingRequest.priority = priority;
 	mAdvertisingRequest.options = kAdvertisingOptions;
@@ -63,39 +60,42 @@ CHIP_ERROR NUSService::Init(const char *name, size_t nameLen, uint8_t priority, 
 
 	mAdvertisingRequest.onStarted = [](int rc) {
 		if (rc == 0) {
-			ChipLogDetail(DeviceLayer, "NUS BLE advertising started");
+			LOG_INF("NUS BLE advertising started");
 		} else {
-			ChipLogError(DeviceLayer, "Failed to start NUS BLE advertising: %d", rc);
+			LOG_ERR("Failed to start NUS BLE advertising: %d", rc);
 		}
 	};
-	mAdvertisingRequest.onStopped = []() { ChipLogDetail(DeviceLayer, "NUS BLE advertising stopped"); };
+	mAdvertisingRequest.onStopped = []() { LOG_DBG("NUS BLE advertising stopped"); };
 
 	settings_load();
-#if (CONFIG_BT_FIXED_PASSKEY)
-	VerifyOrReturnError(bt_passkey_set(kDefaultPasskey) != 0, CHIP_ERROR_INTERNAL);
+#if defined(CONFIG_BT_FIXED_PASSKEY)
+	VerifyOrReturnError(bt_passkey_set(CONFIG_CHIP_NUS_FIXED_PASSKEY) == 0, false);
 #endif
-	VerifyOrReturnError(bt_conn_auth_cb_register(&sConnAuthCallbacks) == 0, CHIP_ERROR_INTERNAL);
-	VerifyOrReturnError(bt_conn_auth_info_cb_register(&sConnAuthInfoCallbacks) == 0, CHIP_ERROR_INTERNAL);
-	VerifyOrReturnError(bt_nus_init(&sNusCallbacks) == 0, CHIP_ERROR_INTERNAL);
+	VerifyOrReturnError(bt_conn_auth_cb_register(&sConnAuthCallbacks) == 0, false);
+	VerifyOrReturnError(bt_conn_auth_info_cb_register(&sConnAuthInfoCallbacks) == 0, false);
+	VerifyOrReturnError(bt_nus_init(&sNusCallbacks) == 0, false);
 
-	return CHIP_NO_ERROR;
+	return true;
 }
 
 void NUSService::StartServer()
 {
-	VerifyOrReturn(!mIsStarted, ChipLogError(DeviceLayer, "NUS service was already started"));
+	if (mIsStarted) {
+		LOG_WRN("NUS service was already started");
+		return;
+	}
 
 	PlatformMgr().LockChipStack();
 	CHIP_ERROR ret = BLEAdvertisingArbiter::InsertRequest(mAdvertisingRequest);
 	PlatformMgr().UnlockChipStack();
 
 	if (CHIP_NO_ERROR != ret) {
-		ChipLogError(DeviceLayer, "Could not start NUS service");
+		LOG_ERR("Could not start NUS service");
 		mIsStarted = false;
 		return;
 	}
 	mIsStarted = true;
-	ChipLogProgress(DeviceLayer, "NUS service started");
+	LOG_INF("NUS service started");
 }
 
 void NUSService::StopServer()
@@ -107,34 +107,35 @@ void NUSService::StopServer()
 	PlatformMgr().UnlockChipStack();
 
 	mIsStarted = false;
-	ChipLogProgress(DeviceLayer, "NUS service stopped");
+	LOG_INF("NUS service stopped");
 }
 
 void NUSService::RxCallback(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	VerifyOrReturn(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2);
-	ChipLogDetail(DeviceLayer, "NUS received: %d bytes", len);
+	LOG_DBG("NUS received: %d bytes", len);
 	GetNUSService().DispatchCommand(reinterpret_cast<const char *>(data), len);
 }
 
-CHIP_ERROR NUSService::RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context)
+bool NUSService::RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context)
 {
-	VerifyOrReturnError(name, CHIP_ERROR_INVALID_ARGUMENT);
+	VerifyOrReturnError(name, false);
+	VerifyOrReturnError(mCommandsCounter <= CONFIG_CHIP_NUS_MAX_COMMANDS, false);
 
 	struct Command newCommand {};
 	memcpy(newCommand.command, name, length);
 	newCommand.commandLen = length;
 	newCommand.callback = callback;
 	newCommand.context = context;
-	mCommandsList.push_back(newCommand);
+	mCommandsList[mCommandsCounter++] = newCommand;
 
-	return CHIP_NO_ERROR;
+	return true;
 }
 
 void NUSService::DispatchCommand(const char *const data, uint16_t len)
 {
-	for (auto c : mCommandsList) {
-		if (strncmp(data, c.command, len) == 0) {
+	for (const auto &c : mCommandsList) {
+		if (strncmp(data, c.command, len) == 0 && len == strlen(c.command)) {
 			if (c.callback) {
 				PlatformMgr().LockChipStack();
 				c.callback(c.context);
@@ -143,82 +144,76 @@ void NUSService::DispatchCommand(const char *const data, uint16_t len)
 			return;
 		}
 	}
-	ChipLogError(DeviceLayer, "NUS command unkown!");
+	LOG_ERR("NUS command unkown!");
 }
 
-CHIP_ERROR NUSService::SendData(const char *const data, size_t length)
+bool NUSService::SendData(const char *const data, size_t length)
 {
-	VerifyOrReturnError(mBTConnection, CHIP_ERROR_SENDING_BLOCKED);
-	VerifyOrReturnError(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2,
-			    CHIP_ERROR_SENDING_BLOCKED);
+	VerifyOrReturnError(mIsStarted && mBTConnection, false);
+	VerifyOrReturnError(mBTConnection, false);
+	VerifyOrReturnError(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2, false);
 	VerifyOrReturnError(bt_nus_send(mBTConnection, reinterpret_cast<const uint8_t *const>(data), length) == 0,
-			    CHIP_ERROR_SENDING_BLOCKED);
-	return CHIP_NO_ERROR;
+			    false);
+	return true;
 }
 
 void NUSService::Connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
-		ChipLogError(DeviceLayer, "NUS Connection failed (err %u)", err);
+		LOG_ERR("NUS Connection failed (err %u)", err);
 		return;
 	}
 
 	bt_conn_set_security(conn, BT_SECURITY_L3);
 
-	char addr[BT_ADDR_LE_STR_LEN];
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	ChipLogDetail(DeviceLayer, "NUS BT Connected to %s", addr);
+	LOG_INF("NUS BT Connected to %s", LogAddress(conn));
 }
 
 void NUSService::Disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	ChipLogProgress(DeviceLayer, "NUS BT Disconnected from %s (reason %u)", addr, reason);
+	LOG_INF("NUS BT Disconnected from %s (reason %u)", LogAddress(conn), reason);
+	if (GetNUSService().mBTConnection) {
+		bt_conn_unref(GetNUSService().mBTConnection);
+	}
 }
 
 void NUSService::SecurityChanged(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	if (!err) {
-		char addr[BT_ADDR_LE_STR_LEN];
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-		ChipLogDetail(DeviceLayer, "NUS BT Security changed: %s level %u", addr, level);
-
-		GetNUSService().mBTConnection = bt_conn_ref(conn);
+		LOG_DBG("NUS BT Security changed: %s level %u", LogAddress(conn), level);
 	} else {
-		ChipLogError(DeviceLayer, "NUS BT Security failed: level %u err %d", level, err);
+		LOG_ERR("NUS BT Security failed: level %u err %d", level, err);
 	}
 }
 
 void NUSService::AuthPasskeyDisplay(struct bt_conn *conn, unsigned int passkey)
 {
-	ChipLogProgress(DeviceLayer, "PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: %d", passkey);
+	LOG_INF("PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: %d", passkey);
 }
 
 void NUSService::AuthCancel(struct bt_conn *conn)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	ChipLogProgress(DeviceLayer, "NUS BT Pairing cancelled: %s", addr);
+	LOG_INF("NUS BT Pairing cancelled: %s", LogAddress(conn));
 
 	bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 }
 
 void NUSService::PairingComplete(struct bt_conn *conn, bool bonded)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	ChipLogDetail(DeviceLayer, "NUS BT Pairing completed: %s, bonded: %d", addr, bonded);
+	LOG_DBG("NUS BT Pairing completed: %s, bonded: %d", LogAddress(conn), bonded);
 }
 
 void NUSService::PairingFailed(struct bt_conn *conn, enum bt_security_err reason)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	ChipLogError(DeviceLayer, "NUS BT Pairing failed to %s : reason %d", addr, static_cast<uint8_t>(reason));
+	LOG_ERR("NUS BT Pairing failed to %s : reason %d", LogAddress(conn), static_cast<uint8_t>(reason));
+}
+
+char* NUSService::LogAddress(struct bt_conn *conn){
+#if CONFIG_LOG
+	static char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	return addr;
+#endif
+	return NULL;
 }

--- a/samples/matter/common/src/bt_nus_service.h
+++ b/samples/matter/common/src/bt_nus_service.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "app_event.h"
+
+#include <platform/Zephyr/BLEAdvertisingArbiter.h>
+
+#include <bluetooth/services/nus.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/sys/ring_buffer.h>
+
+#include <lib/core/CHIPError.h>
+
+#include <list>
+
+class NUSService {
+public:
+	using CommandCallback = void (*)(void *context);
+	struct Command {
+		char command[CONFIG_CHIP_NUS_MAX_COMMAND_LEN];
+		size_t commandLen;
+		CommandCallback callback;
+		void *context;
+	};
+
+	/**
+	 * @brief Initialize BLE Lock service
+	 *
+	 * Initialize internal structures and register necessary commands in BLE service server.
+	 */
+	CHIP_ERROR Init(const char *name, size_t nameLen, uint8_t priority, uint16_t minInterval, uint16_t maxInterval);
+
+	/**
+	 * @brief Start BLE Lock service server
+	 *
+	 * Register BLE Lock service that supports controlling lock and unlock operations
+	 * using BLE commands. The BLE Lock service may begin immediately.
+	 */
+	void StartServer();
+
+	/**
+	 * @brief Stop BLE Lock service server
+	 *
+	 * Unregister BLE Lock service that supports controlling lock and unlock operations
+	 * using BLE commands. The BLE Lock service will be disabled and the next service with the highest priority begin immediately.
+	 */
+	void StopServer();
+
+	/**
+	 * @brief Send data to the connected device
+	 * 
+	 * Send data to the connected and paired device.
+	 * 
+	 * @return CHIP_ERROR_SENDING_BLOCKED if the secure connection to the device was not established 
+	 */
+	CHIP_ERROR SendData(const char *const data, size_t length);
+
+	/**
+	 * @brief Register a new command for NUS service
+	 * 
+	 * The new command consist of a callback which will be call when the device receives provided command name.
+	 * 
+	 * @return CHIP_ERROR 
+	 */
+	CHIP_ERROR RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context);
+
+	friend NUSService &GetLockNUSService();
+	static NUSService sInstance;
+
+	/**
+	 * Static callbacks for BLE connection
+	*/
+	static void Connected(struct bt_conn *conn, uint8_t err);
+	static void Disconnected(struct bt_conn *conn, uint8_t reason);
+	static void SecurityChanged(struct bt_conn *conn, bt_security_t level, enum bt_security_err err);
+
+private:
+
+	void DispatchCommand(const char *const data, uint16_t len);
+
+	static void RxCallback(struct bt_conn *conn, const uint8_t *const data, uint16_t len);
+	static void AuthPasskeyDisplay(struct bt_conn *conn, unsigned int passkey);
+	static void AuthPasskeyConfirm(struct bt_conn *conn, unsigned int passkey);
+	static void AuthCancel(struct bt_conn *conn);
+	static void PairingComplete(struct bt_conn *conn, bool bonded);
+	static void PairingFailed(struct bt_conn *conn, enum bt_security_err reason);
+
+	static struct bt_conn_auth_cb sConnAuthCallbacks;
+	static struct bt_conn_auth_info_cb sConnAuthInfoCallbacks;
+	static struct bt_nus_cb sNusCallbacks;
+
+	bool mIsStarted = false;
+	chip::DeviceLayer::BLEAdvertisingArbiter::Request mAdvertisingRequest = {};
+	std::array<bt_data, 2> mAdvertisingItems;
+	std::array<bt_data, 1> mServiceItems;
+	std::list<Command> mCommandsList;
+	struct bt_conn *mBTConnection;
+
+};
+
+inline NUSService &GetNUSService()
+{
+	return NUSService::sInstance;
+}

--- a/samples/matter/common/src/bt_nus_service.h
+++ b/samples/matter/common/src/bt_nus_service.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -13,11 +13,6 @@
 #include <bluetooth/services/nus.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/sys/ring_buffer.h>
-
-#include <lib/core/CHIPError.h>
-
-#include <list>
 
 class NUSService {
 public:
@@ -30,25 +25,25 @@ public:
 	};
 
 	/**
-	 * @brief Initialize BLE Lock service
+	 * @brief Initialize Nordic UART Service 
 	 *
-	 * Initialize internal structures and register necessary commands in BLE service server.
+	 * Initialize internal structures and set Bluetooth LE advertisement parameters
 	 */
-	CHIP_ERROR Init(const char *name, size_t nameLen, uint8_t priority, uint16_t minInterval, uint16_t maxInterval);
+	bool Init(uint8_t priority, uint16_t minInterval, uint16_t maxInterval);
 
 	/**
-	 * @brief Start BLE Lock service server
+	 * @brief Start Nordic UART Service server
 	 *
-	 * Register BLE Lock service that supports controlling lock and unlock operations
-	 * using BLE commands. The BLE Lock service may begin immediately.
+	 * Register Nordic UART Service that supports controlling lock and unlock operations
+	 * using BLE commands. The Nordic UART Service  may begin immediately.
 	 */
 	void StartServer();
 
 	/**
-	 * @brief Stop BLE Lock service server
+	 * @brief Stop Nordic UART Service server
 	 *
-	 * Unregister BLE Lock service that supports controlling lock and unlock operations
-	 * using BLE commands. The BLE Lock service will be disabled and the next service with the highest priority begin immediately.
+	 * Unregister Nordic UART Service  that supports controlling lock and unlock operations
+	 * using BLE commands. The Nordic UART Service  will be disabled and the next service with the highest priority begin immediately.
 	 */
 	void StopServer();
 
@@ -59,7 +54,7 @@ public:
 	 * 
 	 * @return CHIP_ERROR_SENDING_BLOCKED if the secure connection to the device was not established 
 	 */
-	CHIP_ERROR SendData(const char *const data, size_t length);
+	bool SendData(const char *const data, size_t length);
 
 	/**
 	 * @brief Register a new command for NUS service
@@ -68,7 +63,7 @@ public:
 	 * 
 	 * @return CHIP_ERROR 
 	 */
-	CHIP_ERROR RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context);
+	bool RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context);
 
 	friend NUSService &GetLockNUSService();
 	static NUSService sInstance;
@@ -86,10 +81,10 @@ private:
 
 	static void RxCallback(struct bt_conn *conn, const uint8_t *const data, uint16_t len);
 	static void AuthPasskeyDisplay(struct bt_conn *conn, unsigned int passkey);
-	static void AuthPasskeyConfirm(struct bt_conn *conn, unsigned int passkey);
 	static void AuthCancel(struct bt_conn *conn);
 	static void PairingComplete(struct bt_conn *conn, bool bonded);
 	static void PairingFailed(struct bt_conn *conn, enum bt_security_err reason);
+	static char* LogAddress(struct bt_conn *conn);
 
 	static struct bt_conn_auth_cb sConnAuthCallbacks;
 	static struct bt_conn_auth_info_cb sConnAuthInfoCallbacks;
@@ -99,8 +94,10 @@ private:
 	chip::DeviceLayer::BLEAdvertisingArbiter::Request mAdvertisingRequest = {};
 	std::array<bt_data, 2> mAdvertisingItems;
 	std::array<bt_data, 1> mServiceItems;
-	std::list<Command> mCommandsList;
+	std::array<Command, CONFIG_CHIP_NUS_MAX_COMMANDS> mCommandsList;
+	uint8_t mCommandsCounter = 0;
 	struct bt_conn *mBTConnection;
+
 
 };
 

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -55,6 +55,10 @@ if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 
+if(CONFIG_CHIP_NUS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/bt_nus_service.cpp)
+endif()
+
 if(CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu_over_smp.cpp)
 endif()

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -98,16 +98,16 @@ The Thread and Wi-Fi switching also supports :ref:`dedicated Device Firmware Upg
 
 .. _matter_lock_sample_ble_nus:
 
-Matter BLE NUS (Nordic UART Service)
+Matter Bluetooth LE NUS (Nordic UART Service)
 =========================================
 
 .. matter_door_lock_sample_lock_nus_desc_start
 
-The Matter BLE NUS is an simple implementation of Nordic UART Service that allows to declare specific commands for a Matter sample and use them to control device remotely via BLE.
-This service is only an example of how to implement additional BLE service within a Matter sample and use it to specific purpose.
-You can create own proprietary service and add it to BLE Advertising Arbiter to use it with a Matter sample.
-You can enable this feature by setting the ``-DCONFIG_CHIP_NUS_SERVICE=y`` kconfig.
-Matter BLE NUS requires a secure connection with your mobile phone.
+The Matter Bluetooth LE NUS is an simple implementation of Nordic UART Service that allows to declare specific commands for a Matter sample and use them to control device remotely via Bluetooth LE.
+This service is only an example of how to implement additional Bluetooth LE service within a Matter sample and use it to specific purpose.
+You can create own proprietary service and add it to Bluetooth LE Advertising Arbiter to use it with a Matter sample.
+You can enable this feature by setting the ``-DCONFIG_CHIP_NUS=y`` kconfig.
+Matter Bluetooth LE NUS requires a secure connection with your mobile phone.
 Depending on build types (``debug`` or ``release``) a PIN code will be different:
    
 * In the ``debug`` build type the secure PIN code is generated randomly and printed in log console in the following way:
@@ -510,7 +510,7 @@ Complete the following steps to generate the Matter OTA combined image file:
 .. note::
     Keep the order in which the files are passed to the script, given that the Thread variant image file must be passed in front of the Wi-Fi variant image.
 
-Testing Lock BLE Nordic UART Service
+Testing Lock Bluetooth LE Nordic UART Service
 ====================================
 
 To test this feature, complete the following steps:
@@ -521,7 +521,7 @@ To test this feature, complete the following steps:
 
    .. code-block:: console
 
-      west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_NUS_SERVICE=y 
+      west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_NUS=y 
 
 #. Program the application to the kit using the following command:
 
@@ -545,7 +545,7 @@ To test this feature, complete the following steps:
 
    * Read a randomly generated passkey from the console logs (Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase) and enter the passcode on your phone.
 
-#. Wait for a while to establish the BLE connection between a phone and a nRF board.
+#. Wait for a while to establish the Bluetooth LE connection between a phone and a nRF board.
 
 #. In the app record two macros:
 
@@ -555,8 +555,8 @@ To test this feature, complete the following steps:
 
 #. Tap on generated macros and observe the ``LED 2`` on the nRF board.
 
-You can also use Matter Lock BLE NUS when the device is connected to the Thread network.
-The BLE connection between a phone and an nRF board will be suspended when the commissioning to Matter network is in progress or there is an active session of BLE DFU.
+You can use Matter Lock Bluetooth LE NUS when the device is connected to the Thread network.
+The Bluetooth LE connection between a phone and an nRF board will be suspended when the commissioning to Matter network is in progress or there is an active session of SMP DFU.
 
 Dependencies
 ************

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -118,6 +118,7 @@ Depending on build types (``debug`` or ``release``) a PIN code will be different
 
 * In the ``release`` build type the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards than via log console.
 
+You can setup the secure PIN and enable it by adding 
 .. matter_door_lock_sample_lock_nus_desc_end
 
 In the Door Lock sample there were two commands implemented.
@@ -511,13 +512,14 @@ Complete the following steps to generate the Matter OTA combined image file:
     Keep the order in which the files are passed to the script, given that the Thread variant image file must be passed in front of the Wi-Fi variant image.
 
 Testing Lock Bluetooth LE Nordic UART Service
-====================================
+=============================================
 
 To test this feature, complete the following steps:
 
 #. Install `nRF Toolbox <https://www.nordicsemi.com/Products/Development-tools/nrf-toolbox>`_ on Android or iOS phone.
 
-#. Build the door lock application for Matter over Thread:
+#. Build the door lock application for Matter over Thread with the ``CONFIG_CHIP_NUS`` kconfig enabled.
+In this example we use the nRF52840 board, but you can build also for nrf5340 board:
 
    .. code-block:: console
 
@@ -529,11 +531,11 @@ To test this feature, complete the following steps:
 
       west flash --erase
 
-#. If you are built the sample in ``debug`` build type, connect the board to your favorite UART console to see the LOGs from the device.
+#. If you built the sample in ``debug`` build type, connect the board to your favorite UART console to see the LOGs from the device.
 
 #. Select ``Universal Asynchronous Receiver/Transmitter UART`` from the list in the nRF Toolbox application.
 
-#. Tap on ``Connect`` and uncheck ``Filter by Service UUID`` in iOS app or ``UUID`` field in Android app.
+#. Tap on ``Connect``
 
 #. Select ``MatterLock_NUS`` from the list of available device.
 
@@ -545,7 +547,7 @@ To test this feature, complete the following steps:
 
    * Read a randomly generated passkey from the console logs (Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase) and enter the passcode on your phone.
 
-#. Wait for a while to establish the Bluetooth LE connection between a phone and a nRF board.
+#. Wait for a while to establish the Bluetooth LE connection between a phone and an nRF board.
 
 #. In the app record two macros:
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -36,6 +36,8 @@ This requires additional hardware depending on the setup you choose.
 .. note::
     |matter_gn_required_note|
 
+If you want to enable and test :ref:`matter_lock_sample_ble_nus`, you also need a smartphone with either Android or iOS.
+
 IPv6 network support
 ====================
 
@@ -98,41 +100,34 @@ The Thread and Wi-Fi switching also supports :ref:`dedicated Device Firmware Upg
 
 .. _matter_lock_sample_ble_nus:
 
-Matter Bluetooth LE NUS (Nordic UART Service)
-=========================================
+Extended Matter Bluetooth LE with Nordic UART Service
+=====================================================
 
 .. matter_door_lock_sample_lock_nus_desc_start
 
-The Matter Bluetooth LE NUS is an simple implementation of Nordic UART Service that allows to declare specific commands for a Matter sample and use them to control device remotely via Bluetooth LE.
-This service is only an example of how to implement additional Bluetooth LE service within a Matter sample and use it to specific purpose.
-You can create own proprietary service and add it to Bluetooth LE Advertising Arbiter to use it with a Matter sample.
-You can enable this feature by setting the ``-DCONFIG_CHIP_NUS=y`` kconfig.
-Matter Bluetooth LE NUS requires a secure connection with your mobile phone.
-Depending on build types (``debug`` or ``release``) a PIN code will be different:
-   
-* In the ``debug`` build type the secure PIN code is generated randomly and printed in log console in the following way:
+Matter over Thread lets you can integrate an additional Bluetooth LE service with any Matter application.
+The Matter door lock sample demonstrates this integration by providing a basic implementation of the Matter Bluetooth LE with :ref:`Nordic UART Service <nus_service_readme>`.
+Thanks to this solution, you can declare commands specific to a Matter sample and use them to control the device remotely through Bluetooth LE.
 
-   .. code-block:: console
-
-      PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: 165768
-
-* In the ``release`` build type the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards than via log console.
-
-You can setup the secure PIN and enable it by adding 
 .. matter_door_lock_sample_lock_nus_desc_end
 
-In the Door Lock sample there were two commands implemented.
+In the door lock sample, you can use the following commands with the Bluetooth LE with NUS:
 
-   * ``Lock`` - To lock the door of the connected device.
+* ``Lock`` - To lock the door of the connected device.
+* ``Unlock`` - To unlock the door of the connected device.
 
-   * ``UnLock`` - To unlock the door of the connected device.
+If the device is already connected to the Matter network, the notification about changing the lock state will be send to Matter controller.
 
-If the device is already connected to the matter network, the notification about changing lock state will be send to Matter Controller.
+See `Enabling Matter Bluetooth LE with Nordic UART Service`_ and `Testing door lock using Bluetooth LE with Nordic UART Service`_ for more information about how to configure and test this feature with this sample.
+
+.. _matter_lock_sample_configuration:
 
 Configuration
 *************
 
 |config|
+
+.. _matter_lock_sample_configuration_build_types:
 
 Matter door lock build types
 ============================
@@ -164,6 +159,8 @@ This sample supports the following build types, depending on the selected board:
     The ``debug`` build type is used by default if no build type is explicitly selected.
 
 .. matter_door_lock_sample_configuration_file_types_end
+
+.. _matter_lock_sample_configuration_dfu:
 
 Device Firmware Upgrade support
 ===============================
@@ -206,10 +203,32 @@ For example:
 
 .. matter_door_lock_sample_build_with_dfu_end
 
+.. _matter_lock_sample_configuration_fem:
+
 FEM support
 ===========
 
 .. include:: /includes/sample_fem_support.txt
+
+.. _matter_lock_sample_configuration_nus:
+
+Enabling Matter Bluetooth LE with Nordic UART Service
+=====================================================
+
+You can enable the :ref:`matter_lock_sample_ble_nus` feature by setting the :kconfig:option:`CONFIG_CHIP_NUS` Kconfig option to ``y``.
+
+Matter Bluetooth LE NUS requires a secure connection with a smartphone, which is established using a security PIN code.
+The PIN code is different depending on the build type:
+
+* In the ``debug`` build type, the secure PIN code is generated randomly and printed in the log console in the following way:
+
+  .. code-block:: console
+
+     PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: 165768
+
+* In the ``release`` build type, the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards than in the log console.
+
+See `Testing door lock using Bluetooth LE with Nordic UART Service`_ for more information about how to test this feature.
 
 User interface
 **************
@@ -511,19 +530,18 @@ Complete the following steps to generate the Matter OTA combined image file:
 .. note::
     Keep the order in which the files are passed to the script, given that the Thread variant image file must be passed in front of the Wi-Fi variant image.
 
-Testing Lock Bluetooth LE Nordic UART Service
-=============================================
+Testing door lock using Bluetooth LE with Nordic UART Service
+=============================================================
 
-To test this feature, complete the following steps:
+To test the :ref:`matter_lock_sample_ble_nus` feature, complete the following steps:
 
-#. Install `nRF Toolbox <https://www.nordicsemi.com/Products/Development-tools/nrf-toolbox>`_ on Android or iOS phone.
-
-#. Build the door lock application for Matter over Thread with the ``CONFIG_CHIP_NUS`` kconfig enabled.
-In this example we use the nRF52840 board, but you can build also for nrf5340 board:
+#. Install `nRF Toolbox`_ on your Android or iOS smartphone.
+#. Build the door lock application for Matter over Thread with the :kconfig:option:`CONFIG_CHIP_NUS` set to ``y``.
+   For example, if you build from command line for the ``nrf52840dk_nrf52840``, you use the following command:
 
    .. code-block:: console
 
-      west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_NUS=y 
+      west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_NUS=y
 
 #. Program the application to the kit using the following command:
 
@@ -531,34 +549,33 @@ In this example we use the nRF52840 board, but you can build also for nrf5340 bo
 
       west flash --erase
 
-#. If you built the sample in ``debug`` build type, connect the board to your favorite UART console to see the LOGs from the device.
+#. If you built the sample with the ``debug`` build type, connect the board to an UART console to see the log entries from the device.
+#. Open the nRF Toolbox application on your smartphone.
+#. Select :guilabel:`Universal Asynchronous Receiver/Transmitter UART` from the list in the nRF Toolbox application.
+#. Tap on :guilabel:`Connect`.
+   The application connects to the devices connected through UART.
+#. Select :guilabel:`MatterLock_NUS` from the list of available devices.
+   The Bluetooth Pairing Request with an input field for passkey appears on the screen (on iOS) or as an notification (on Android).
+#. Depending on the build type you are using:
 
-#. Select ``Universal Asynchronous Receiver/Transmitter UART`` from the list in the nRF Toolbox application.
+   * For the ``release`` build type: Enter the passkey ``123456``.
+   * For the ``debug`` build type, complete the following steps:
 
-#. Tap on ``Connect``
+     1. Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase.
+     #. Read the randomly generated passkey from the console logs.
+     #. Enter the passcode on your smartphone.
 
-#. Select ``MatterLock_NUS`` from the list of available device.
+#. Wait for the Bluetooth LE connection to be established between the smartphone and the nRF board.
+#. In the nRF Toolbox application, add the following macros as :
 
-#. The Bluetooth Pairing Request with an input field for passkey should appear on the screen (iOS) or as an notification (Android).
+   * ``Lock`` as the Command value type ``Text`` and any image.
 
-#. Depending on build type:
+   * ``Unlock`` as the Command value type ``Text`` and any image.
 
-   * Enter the passkey ``123456``  if the build type is ``release``.
+#. Tap on the generated macros and observe the **LED 2** on the nRF board.
 
-   * Read a randomly generated passkey from the console logs (Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase) and enter the passcode on your phone.
-
-#. Wait for a while to establish the Bluetooth LE connection between a phone and an nRF board.
-
-#. In the app record two macros:
-
-   * ``Lock`` as Command value type ``Text`` and any image.
-
-   * ``UnLock`` as Command value type ``Text`` and any image.
-
-#. Tap on generated macros and observe the ``LED 2`` on the nRF board.
-
-You can use Matter Lock Bluetooth LE NUS when the device is connected to the Thread network.
-The Bluetooth LE connection between a phone and an nRF board will be suspended when the commissioning to Matter network is in progress or there is an active session of SMP DFU.
+You can use the Matter door lock Bluetooth LE NUS only when the device is connected to a Matter over Thread network.
+The Bluetooth LE connection between a phone and the nRF board will be suspended when the commissioning to the Matter network is in progress or there is an active session of SMP DFU.
 
 Dependencies
 ************

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -96,6 +96,38 @@ The device is rebooted into the MCUboot bootloader, which replaces the current v
 See `Matter door lock build types`_, `Selecting a build type`_, and :ref:`matter_lock_sample_switching_thread_wifi` for more information about how to configure and test this feature with this sample.
 The Thread and Wi-Fi switching also supports :ref:`dedicated Device Firmware Upgrades <matter_lock_sample_switching_thread_wifi_dfu>`.
 
+.. _matter_lock_sample_ble_nus:
+
+Matter BLE NUS (Nordic UART Service)
+=========================================
+
+.. matter_door_lock_sample_lock_nus_desc_start
+
+The Matter BLE NUS is an simple implementation of Nordic UART Service that allows to declare specific commands for a Matter sample and use them to control device remotely via BLE.
+This service is only an example of how to implement additional BLE service within a Matter sample and use it to specific purpose.
+You can create own proprietary service and add it to BLE Advertising Arbiter to use it with a Matter sample.
+You can enable this feature by setting the ``-DCONFIG_CHIP_NUS_SERVICE=y`` kconfig.
+Matter BLE NUS requires a secure connection with your mobile phone.
+Depending on build types (``debug`` or ``release``) a PIN code will be different:
+   
+* In the ``debug`` build type the secure PIN code is generated randomly and printed in log console in the following way:
+
+   .. code-block:: console
+
+      PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: 165768
+
+* In the ``release`` build type the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards than via log console.
+
+.. matter_door_lock_sample_lock_nus_desc_end
+
+In the Door Lock sample there were two commands implemented.
+
+   * ``Lock`` - To lock the door of the connected device.
+
+   * ``UnLock`` - To unlock the door of the connected device.
+
+If the device is already connected to the matter network, the notification about changing lock state will be send to Matter Controller.
+
 Configuration
 *************
 
@@ -477,6 +509,54 @@ Complete the following steps to generate the Matter OTA combined image file:
 
 .. note::
     Keep the order in which the files are passed to the script, given that the Thread variant image file must be passed in front of the Wi-Fi variant image.
+
+Testing Lock BLE Nordic UART Service
+====================================
+
+To test this feature, complete the following steps:
+
+#. Install `nRF Toolbox <https://www.nordicsemi.com/Products/Development-tools/nrf-toolbox>`_ on Android or iOS phone.
+
+#. Build the door lock application for Matter over Thread:
+
+   .. code-block:: console
+
+      west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_NUS_SERVICE=y 
+
+#. Program the application to the kit using the following command:
+
+   .. code-block:: console
+
+      west flash --erase
+
+#. If you are built the sample in ``debug`` build type, connect the board to your favorite UART console to see the LOGs from the device.
+
+#. Select ``Universal Asynchronous Receiver/Transmitter UART`` from the list in the nRF Toolbox application.
+
+#. Tap on ``Connect`` and uncheck ``Filter by Service UUID`` in iOS app or ``UUID`` field in Android app.
+
+#. Select ``MatterLock_NUS`` from the list of available device.
+
+#. The Bluetooth Pairing Request with an input field for passkey should appear on the screen (iOS) or as an notification (Android).
+
+#. Depending on build type:
+
+   * Enter the passkey ``123456``  if the build type is ``release``.
+
+   * Read a randomly generated passkey from the console logs (Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase) and enter the passcode on your phone.
+
+#. Wait for a while to establish the BLE connection between a phone and a nRF board.
+
+#. In the app record two macros:
+
+   * ``Lock`` as Command value type ``Text`` and any image.
+
+   * ``UnLock`` as Command value type ``Text`` and any image.
+
+#. Tap on generated macros and observe the ``LED 2`` on the nRF board.
+
+You can also use Matter Lock BLE NUS when the device is connected to the Thread network.
+The BLE connection between a phone and an nRF board will be suspended when the commissioning to Matter network is in progress or there is an active session of BLE DFU.
 
 Dependencies
 ************

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -20,6 +20,7 @@ CONFIG_DK_LIBRARY=y
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
+CONFIG_BT_FIXED_PASSKEY=y
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/lock/src/bolt_lock_manager.cpp
+++ b/samples/matter/lock/src/bolt_lock_manager.cpp
@@ -23,7 +23,6 @@ namespace
 constexpr uint16_t kAdvertisingIntervalMin = 400;
 constexpr uint16_t kAdvertisingIntervalMax = 500;
 constexpr uint8_t kLockNUSPriority = 2;
-constexpr char kLockNUSName[] = "MatterLock_NUS";
 } // namespace
 
 void BoltLockManager::NUSLockCallback(void *context)
@@ -43,7 +42,6 @@ void BoltLockManager::NUSUnlockCallback(void *context)
 		ChipLogProgress(Zcl, "Device is already unlocked");
 	} else {
 		BoltLockMgr().Unlock(BoltLockManager::OperationSource::kProprietaryRemote);
-		
 	}
 }
 #endif
@@ -53,8 +51,7 @@ void BoltLockManager::Init(StateChangeCallback callback)
 	mStateChangeCallback = callback;
 
 #ifdef CONFIG_CHIP_NUS
-	if (CHIP_NO_ERROR != GetNUSService().Init(kLockNUSName, sizeof(kLockNUSName) - 1, kLockNUSPriority,
-						  kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
+	if (!GetNUSService().Init(kLockNUSPriority, kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
 		ChipLogError(Zcl, "Cannot initialize NUS service");
 	}
 	GetNUSService().RegisterCommand("Lock", sizeof("Lock"), NUSLockCallback, nullptr);

--- a/samples/matter/lock/src/bolt_lock_manager.h
+++ b/samples/matter/lock/src/bolt_lock_manager.h
@@ -66,6 +66,9 @@ private:
 
 	void SetState(State state, OperationSource source);
 
+	static void NUSLockCallback(void* context);
+	static void NUSUnlockCallback(void* context);
+
 	static void ActuatorTimerEventHandler(k_timer *timer);
 	static void ActuatorAppEventHandler(const AppEvent &aEvent);
 	friend BoltLockManager &BoltLockMgr();

--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.3.0
+      revision: pull/229/head
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The Matter NUS service allows to create a Nordic UART BLE Service for each sample to control its behaviour by using pre-defined commands.
Connection to the device is secure and requires providing a random-generated pincode.